### PR TITLE
Add automatic reload to the env variables.

### DIFF
--- a/index.py
+++ b/index.py
@@ -9,7 +9,7 @@ import os
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     # Class attribute for brain
     brain = None
-    load_dotenv()
+    load_dotenv(override=True)
 
     @classmethod
     def initialize_brain(cls):


### PR DESCRIPTION
In Python, the env variables get cached in the terminal session. Therefore either the terminal session needs to be restarted to pick up the new one. However if we add this override the cached version will not be used.